### PR TITLE
HFSTMorphAndLemma to use take the token from the tokenizer's output

### DIFF
--- a/Lang_Hungarian/src/hu/nytud/gate/morph/HFSTMorphAndLemma.java
+++ b/Lang_Hungarian/src/hu/nytud/gate/morph/HFSTMorphAndLemma.java
@@ -124,10 +124,8 @@ public class HFSTMorphAndLemma extends AbstractLanguageAnalyser {
 	        
 	        while (tokenIter.hasNext()) {
 	        	Annotation currentToken = tokenIter.next();
-	        	worker.addWord(document.getContent().getContent(
-	        			currentToken.getStartNode().getOffset(),
-	        			currentToken.getEndNode().getOffset()
-				).toString());
+                String token = (String)currentToken.getFeatures().get(TOKEN_STRING_FEATURE_NAME);
+	        	worker.addWord(token);
 	        }
 	        
 	        tokenIter = tokensAS.iterator(); int n=0;


### PR DESCRIPTION
Proof-of-concept fix for #10. Unfortunately PurePos, the next module in line, also takes its input from the original text, so the solution is not fully consistent at this stage.